### PR TITLE
Removing class used to recalutate parent height

### DIFF
--- a/apps/topics/templates/topics/all.html
+++ b/apps/topics/templates/topics/all.html
@@ -26,7 +26,7 @@
           {% endif %}
         </div>
         <div class="c2">
-          <div class="vAlign">
+          <div>
             <h3 class="normal"><a class="brandColor" href="{{ url('topics_show', slug=topic.slug) }}">{{ topic.name }}</a></h3>
             <p class="serif">{{ topic.description }}</p>
             {# note: once we have models for projects, research, etc then this

--- a/apps/topics/templates/topics/show.html
+++ b/apps/topics/templates/topics/show.html
@@ -46,7 +46,7 @@
           {% endif -%}
         </div>
         <div class="c3">
-          <div class="vAlign">
+          <div>
             <h3 class="normal"><a class="brandColor" href="{{ url('projects_show', slug=project.slug) }}">{{ project.name }}</a></h3>
             <p class="serif">{{ project.description }}</p>
           </div>


### PR DESCRIPTION
The recalculation of heights lead of choppy display issues so removed for now - I think with real data the visual effect wouldn't have been as intended anyways.

Easy to put back in, refactor if needed.
