### PR TITLE
add note to all pages that site is archived

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -94,6 +94,13 @@
           {# end #header #}
         {% endblock %}
 
+        <p class="container" style="width: 876px; padding: 10px; border: 1px solid #FF9999; margin-bottom: 10px; background: #FFFF99; color: black; font-size: 1.5em;">
+          Mozilla Labs is no longer active, so this website has been archived,
+          and the information on it is no longer reliable.  For more information
+          about Mozilla, see
+          <a href="https://www.mozilla.org/">Mozilla's main website</a>.
+        </p>
+
         {% block content %}{% endblock %}
 
     {% block site_footer %}


### PR DESCRIPTION
This branch adds a note to all pages that the Mozilla Labs website is archived. It looks like this:

<img width="951" alt="screen shot 2015-11-13 at 10 56 39" src="https://cloud.githubusercontent.com/assets/305455/11154608/40d4034a-89f5-11e5-97e0-4f4dfdad0830.png">

The style comes from the note on archived pages of the mozilla.org website, f.e. http://www-archive.mozilla.org/unix/remote.html. I'm doing this to resolve bug https://bugzilla.mozilla.org/show_bug.cgi?id=1199848.

I've run into trouble building the site locally (using the instructions in INSTALL.md), but I've tested by using developer tools to insert the chunk of HTML into the appropriate place on various pages of the live site to confirm that it looks as expected.

I embedded the style into the HTML in this case (instead of putting it into an external stylesheet) because the site is defunct, and this is (presumably) the last change we will make to it, so I optimized for simplicity over maintainability.
